### PR TITLE
quick and dirty macOS build fix

### DIFF
--- a/extensions/standard-processors/processors/AttributeRollingWindow.cpp
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.cpp
@@ -30,8 +30,8 @@ void AttributeRollingWindow::onSchedule(core::ProcessContext* context, core::Pro
   gsl_Expects(context);
   time_window_ = context->getProperty<core::TimePeriodValue>(TimeWindow)
       | utils::transform(&core::TimePeriodValue::getMilliseconds);
-  window_length_ = context->getProperty<size_t>(WindowLength)
-      | utils::filter([](size_t value) { return value > 0; });
+  window_length_ = context->getProperty<uint64_t>(WindowLength)
+      | utils::filter([](uint64_t value) { return value > 0; });
   if (!time_window_ && !window_length_) {
     throw minifi::Exception{ExceptionType::PROCESS_SCHEDULE_EXCEPTION, "Either 'Time window' or 'Window length' must be set"};
   }

--- a/extensions/standard-processors/processors/AttributeRollingWindow.h
+++ b/extensions/standard-processors/processors/AttributeRollingWindow.h
@@ -98,7 +98,7 @@ class AttributeRollingWindow final : public core::AbstractProcessor<AttributeRol
   standard::utils::RollingWindow<std::chrono::time_point<std::chrono::system_clock>, double> state_;
 
   std::optional<std::chrono::milliseconds> time_window_{};
-  std::optional<size_t> window_length_{};
+  std::optional<uint64_t> window_length_{};
   std::string attribute_name_prefix_;
   std::shared_ptr<core::logging::Logger> logger_ = core::logging::LoggerFactory<AttributeRollingWindow>::getLogger(uuid_);
 };


### PR DESCRIPTION
Due to size_t size on macOS the cast inside the ConfigurableComponent.h:242
`      value = static_cast<T>(property.getValue());  // cast throws if the value is invalid
`
is ambigous